### PR TITLE
Add support for version 4 of the protocol

### DIFF
--- a/pytimefliplib/async_client.py
+++ b/pytimefliplib/async_client.py
@@ -204,6 +204,29 @@ class AsyncClient:
 
         self.firmware_version = None
 
+        
+        # Assume version 3 as the default for backwards compatibility
+        # The `setup()` function will set these correctly if we are 
+        # at version 4
+        self.get_status = self.get_status_v3
+        self.set_paused = self.set_paused_v3
+        self.set_lock = self.set_lock_v3
+        self.set_auto_pause = self.set_auto_pause_v3
+        self.set_name = self.set_name_v3
+        self.set_password = self.set_password_v3
+        self.get_status = self.get_status_v3
+        self.get_history = self.get_history_v3
+        self.get_calibration_version = \
+            self.get_calibration_version_v3
+        self.set_calibration_version = \
+            self.set_calibration_version_v3
+
+        # Provide backwards compatibility with old-style of naming schemes
+        self.lock = self.set_lock
+        self.pause = self.set_paused
+        self.status = self.get_status
+        self.history = self.get_history
+
     # basic BLE actions:
 
     async def connect(self) -> None:
@@ -348,15 +371,8 @@ class AsyncClient:
         firmware_revision = await self.firmware_revision()
         self.firmware_version = float(firmware_revision[4:8])
 
+        # For version 4 these functions are different
         if self.firmware_version >= 3.47:
-            # Consistent functions between versions
-            self.get_status = self.get_status_v3
-            self.set_paused = self.set_pause_v3
-            self.set_lock = self.set_lock_v3
-            self.set_auto_pause = self.set_auto_pause_v3
-            self.set_name = self.set_name_v3
-            self.set_password = self.set_password_v3
-
             # New or changed in version 4
             self.get_time = self.get_time_v4
             self.set_time = self.set_time_v4
@@ -373,12 +389,6 @@ class AsyncClient:
             # Deprecated in version 4
             self.get_calibration_version = self.deprecated_function
             self.set_calibration_version = self.deprecated_function
-        else:
-            self.get_status = self.get_status_v3
-            self.get_calibration_version = \
-                self.get_calibration_version_v3
-            self.set_calibration_version = \
-                self.set_calibration_version_v3
 
         if not await self.login(password):
             raise NotLoggedInError()
@@ -778,7 +788,7 @@ class AsyncClient:
         return ax / divider * multiplier, ay / divider * multiplier, az / divider * multiplier
 
     @requires_login
-    async def set_pause_v3(self, state: bool, force: bool = False) -> bool:
+    async def set_paused_v3(self, state: bool, force: bool = False) -> bool:
         """Set (or unset) pause (command 0x04). Update internal. Requires login.
 
         .. note::

--- a/pytimefliplib/async_client.py
+++ b/pytimefliplib/async_client.py
@@ -45,13 +45,13 @@ CHARACTERISTIC_READ_LENGTHS = {
 
     # timeflip
     'event_data':           20,
-    'accelerometer_data':   -1,  # deprecated
+    'accelerometer_data':   6,  # version 3 only
     'facet':                1,
     'command_result':       20,
     'command_input':        2,
     'double_tap':           -1,
     'system_state':         4,
-    'calibration_version':  -1,  # deprecated
+    'calibration_version':  4,  # vers 3 only
     'password_input':       -1,
     'history_data':         20
 }
@@ -64,13 +64,13 @@ CHARACTERISTIC_WRITE_LENGTHS = {
 
     # timeflip
     'event_data':           -1,
-    'accelerometer_data':   -1,  # deprecated
+    'accelerometer_data':   -1,
     'facet':                -1,
     'command_result':       -1,
     'command_input':        20,
     'double_tap':           -1,
     'system_state':         -1,
-    'calibration_version':  -1,  # deprecated
+    'calibration_version':  4,  # vers 3 only
     'password_input':       6,
     'history_data':         20
 }
@@ -83,13 +83,13 @@ CHARACTERISTIC_NOTIFY_LENGTHS = {
 
     # timeflip
     'event_data':           20,
-    'accelerometer_data':   -1,  # deprecated
+    'accelerometer_data':   -1,
     'facet':                1,
     'command_result':       20,
     'command_input':        20,
     'double_tap':           -1,
     'system_state':         4,
-    'calibration_version':  -1,  # deprecated
+    'calibration_version':  -1,
     'password_input':       6,
     'history_data':         20
 }

--- a/pytimefliplib/async_client.py
+++ b/pytimefliplib/async_client.py
@@ -24,14 +24,14 @@ CHARACTERISTICS = {
     'device_name':          UUID_GENERIC.format(0x2a00),
 
     # timeflip
-    'event_data':           UUID_TIMEFLIP.format(0x6f51), # vers 4.0
-    'accelerometer_data':   UUID_TIMEFLIP.format(0x6f51), # vers 3.0
+    'event_data':           UUID_TIMEFLIP.format(0x6f51),  # vers 4.0
+    'accelerometer_data':   UUID_TIMEFLIP.format(0x6f51),  # vers 3.0
     'facet':                UUID_TIMEFLIP.format(0x6f52),
     'command_result':       UUID_TIMEFLIP.format(0x6f53),
     'command_input':        UUID_TIMEFLIP.format(0x6f54),
     'double_tap':           UUID_TIMEFLIP.format(0x6f55),  # "double tap" is reserved for future use
-    'calibration_version':  UUID_TIMEFLIP.format(0x6f56), # vers 3.0
-    'system_state':         UUID_TIMEFLIP.format(0x6f56), # vers 4.0
+    'calibration_version':  UUID_TIMEFLIP.format(0x6f56),  # vers 3.0
+    'system_state':         UUID_TIMEFLIP.format(0x6f56),  # vers 4.0
     'password_input':       UUID_TIMEFLIP.format(0x6f57),
     'history_data':         UUID_TIMEFLIP.format(0x6f58),
 }
@@ -45,13 +45,13 @@ CHARACTERISTIC_READ_LENGTHS = {
 
     # timeflip
     'event_data':           20,
-    'accelerometer_data':   -1, # deprecated
+    'accelerometer_data':   -1,  # deprecated
     'facet':                1,
     'command_result':       20,
     'command_input':        2,
     'double_tap':           -1,
     'system_state':         4,
-    'calibration_version':  -1, # deprecated
+    'calibration_version':  -1,  # deprecated
     'password_input':       -1,
     'history_data':         20
 }
@@ -64,13 +64,13 @@ CHARACTERISTIC_WRITE_LENGTHS = {
 
     # timeflip
     'event_data':           -1,
-    'accelerometer_data':   -1, # deprecated
+    'accelerometer_data':   -1,  # deprecated
     'facet':                -1,
     'command_result':       -1,
     'command_input':        20,
     'double_tap':           -1,
     'system_state':         -1,
-    'calibration_version':  -1, # deprecated
+    'calibration_version':  -1,  # deprecated
     'password_input':       6,
     'history_data':         20
 }
@@ -83,13 +83,13 @@ CHARACTERISTIC_NOTIFY_LENGTHS = {
 
     # timeflip
     'event_data':           20,
-    'accelerometer_data':   -1, # deprecated
+    'accelerometer_data':   -1,  # deprecated
     'facet':                1,
     'command_result':       20,
     'command_input':        20,
     'double_tap':           -1,
     'system_state':         4,
-    'calibration_version':  -1, # deprecated
+    'calibration_version':  -1,  # deprecated
     'password_input':       6,
     'history_data':         20
 }
@@ -100,8 +100,8 @@ def _com(x):
 
 COMMANDS = {
     'history':              _com(0x01),
-    'history_delete':       _com(0x02), # version 3
-    'history_dump':         _com(0x02), # version 4
+    'history_delete':       _com(0x02),  # version 3
+    'history_dump':         _com(0x02),  # version 4
     'calibration_reset':    _com(0x03),
     'lock_on':              _com([0x04, 0x01]),
     'lock_off':             _com([0x04, 0x02]),
@@ -270,8 +270,6 @@ class AsyncClient:
 
         if length == -1:
             raise ValueError("Characteristic not supported for write")
-        # elif len(data) != length:
-        #     raise ValueError("Incorrect write length provided")
         
         await self.client.write_gatt_char(uuid, data)
 

--- a/pytimefliplib/async_client.py
+++ b/pytimefliplib/async_client.py
@@ -1,7 +1,12 @@
 from bleak import BleakClient
 from functools import wraps
-from typing import Callable, Any, List, Tuple
+from typing import Callable, Any, List, Tuple, Optional
 import struct
+
+TWENTY_ZEROES = [ 0x00, 0x00, 0x00, 0x00, 0x00, 
+                  0x00, 0x00, 0x00, 0x00, 0x00, 
+                  0x00, 0x00, 0x00, 0x00, 0x00, 
+                  0x00, 0x00, 0x00, 0x00, 0x00 ]
 
 UUID_GENERIC = '0000{:x}-0000-1000-8000-00805f9b34fb'
 UUID_TIMEFLIP = 'f119{:x}-71a4-11e6-bdf4-0800200c9a66'
@@ -9,39 +14,109 @@ UUID_TIMEFLIP = 'f119{:x}-71a4-11e6-bdf4-0800200c9a66'
 DEFAULT_PASSWORD = '000000'
 
 BLUETOOTH_ENDIANNESS = 'little'
-TIMEFLIP_ENDIANNESS = BLUETOOTH_ENDIANNESS  # it was not clear, but based on history read out, it is little endian
+#TIMEFLIP_ENDIANNESS = BLUETOOTH_ENDIANNESS  # it was not clear, but based on history read out, it is little endian
+TIMEFLIP_ENDIANNESS = 'big'
 
 CHARACTERISTICS = {
     # generic
-    'battery_level': UUID_GENERIC.format(0x2a19),
-    'firmware_revision': UUID_GENERIC.format(0x2a26),
-    'device_name': UUID_GENERIC.format(0x2a00),
+    'battery_level':        UUID_GENERIC.format(0x2a19),
+    'firmware_revision':    UUID_GENERIC.format(0x2a26),
+    'device_name':          UUID_GENERIC.format(0x2a00),
 
     # timeflip
-    'accelerometer_data': UUID_TIMEFLIP.format(0x6f51),
-    'facet': UUID_TIMEFLIP.format(0x6f52),
-    'command_result': UUID_TIMEFLIP.format(0x6f53),
-    'command_input': UUID_TIMEFLIP.format(0x6f54),
-    'double_tap': UUID_TIMEFLIP.format(0x6f55),  # "double tap" is reserved for future use
-    'calibration_version': UUID_TIMEFLIP.format(0x6f56),
-    'password_input': UUID_TIMEFLIP.format(0x6f57)
+    'event_data':           UUID_TIMEFLIP.format(0x6f51), # vers 4.0
+    'accelerometer_data':   UUID_TIMEFLIP.format(0x6f51), # vers 3.0
+    'facet':                UUID_TIMEFLIP.format(0x6f52),
+    'command_result':       UUID_TIMEFLIP.format(0x6f53),
+    'command_input':        UUID_TIMEFLIP.format(0x6f54),
+    'double_tap':           UUID_TIMEFLIP.format(0x6f55),  # "double tap" is reserved for future use
+    'calibration_version':  UUID_TIMEFLIP.format(0x6f56), # vers 3.0
+    'system_state':         UUID_TIMEFLIP.format(0x6f56), # vers 4.0
+    'password_input':       UUID_TIMEFLIP.format(0x6f57),
+    'history_data':         UUID_TIMEFLIP.format(0x6f58),
 }
 
+# This is per the v 4.0 specification
+CHARACTERISTIC_READ_LENGTHS = {
+    # generic
+    'battery_level':        1,
+    'firmware_revision':    20,
+    'device_name':          20,
+
+    # timeflip
+    'event_data':           20,
+    'accelerometer_data':   -1, # deprecated
+    'facet':                1,
+    'command_result':       20,
+    'command_input':        2,
+    'double_tap':           -1,
+    'system_state':         4,
+    'calibration_version':  -1, # deprecated
+    'password_input':       -1,
+    'history_data':         20
+}
+
+CHARACTERISTIC_WRITE_LENGTHS = {
+    # generic
+    'battery_level':        -1,
+    'firmware_revision':    -1,
+    'device_name':          -1,
+
+    # timeflip
+    'event_data':           -1,
+    'accelerometer_data':   -1, # deprecated
+    'facet':                -1,
+    'command_result':       -1,
+    'command_input':        20,
+    'double_tap':           -1,
+    'system_state':         -1,
+    'calibration_version':  -1, # deprecated
+    'password_input':       6,
+    'history_data':         20
+}
+
+CHARACTERISTIC_NOTIFY_LENGTHS = {
+    # generic
+    'battery_level':        1,
+    'firmware_revision':    -1,
+    'device_name':          -1,
+
+    # timeflip
+    'event_data':           20,
+    'accelerometer_data':   -1, # deprecated
+    'facet':                1,
+    'command_result':       20,
+    'command_input':        20,
+    'double_tap':           -1,
+    'system_state':         4,
+    'calibration_version':  -1, # deprecated
+    'password_input':       6,
+    'history_data':         20
+}
 
 def _com(x):
     return bytearray([x] if type(x) is int else x)
 
 
 COMMANDS = {
-    'history': _com(0x01),
-    'history_delete': _com(0x02),
-    'calibration_reset': _com(0x03),
-    'lock_on': _com([0x04, 0x01]),
-    'lock_off': _com([0x04, 0x02]),
-    # - auto_pause is 0x05
-    'pause_on': _com([0x06, 0x01]),
-    'pause_off': _com([0x06, 0x02]),
-    'status': _com(0x10),
+    'history':              _com(0x01),
+    'history_delete':       _com(0x02), # version 3
+    'history_dump':         _com(0x02), # version 4
+    'calibration_reset':    _com(0x03),
+    'lock_on':              _com([0x04, 0x01]),
+    'lock_off':             _com([0x04, 0x02]),
+    'auto_pause_set':       _com(0x05),
+    'pause_on':             _com([0x06, 0x01]),
+    'pause_off':            _com([0x06, 0x02]),
+    'time_read':            _com(0x07),
+    'time_write':           _com(0x08),
+    'brightness_set':       _com(0x09),
+    'blink_freq_set':       _com(0x0A),
+    'status':               _com(0x10),
+    'color_set':            _com(0x11),
+    'facet_write':          _com(0x13),
+    'facet_read':           _com(0x14),
+    'set_password':         _com(0x30)
 }
 
 
@@ -58,11 +133,21 @@ class NotLoggedInError(TimeFlipRuntimeError):
     def __init__(self):
         super().__init__('Not logged in (incorrect password?)')
 
+class IncorrectPasswordError(TimeFlipRuntimeError):
+    def __init__(self):
+        super().__init__('Incorrect password for device')
 
 class TimeFlipCommandError(TimeFlipRuntimeError):
-
     def __init__(self, command):
         super().__init__('Error while executing {}'.format(command))
+
+class UnimplementedFunctionError(TimeFlipRuntimeError):
+    def __init__(self):
+        super().__init__('Function not implemented in this firmware version')
+
+class DeprecatedFunctionError(TimeFlipRuntimeError):
+    def __init__(self):
+        super().__init__('Function deprecated in this firmware version')
 
 
 def requires_connection(f):
@@ -97,20 +182,27 @@ class AsyncClient:
     """TimeFlip asynchronous client
     """
 
-    def __init__(self, address: str):
+    def __init__(self, address: str, disconnected_callback: Optional[Callable[[BleakClient], None]] = None):
 
         self.address = address
         self.client = None
+        self.disconnected_callback = disconnected_callback
 
         # timeflip states
         self.logged = False
         self.connected = False
         self.facet_callback = None
 
+        self.facet_notify_active = False
+        self.event_notify_active = False
+        self.history_notify_active = False
+
         self.paused = False
         self.locked = False
         self.auto_pause_time = 0
         self.current_facet_value = -1
+
+        self.firmware_version = None
 
     # basic BLE actions:
 
@@ -118,24 +210,46 @@ class AsyncClient:
         """Connect to the device
         """
 
-        self.client = BleakClient(self.address)
+        self.client = BleakClient(self.address, disconnected_callback=self.disconnected_callback)
         self.connected = await self.client.connect()
 
     @requires_connection
-    async def base_char_read(self, uuid: str) -> bytearray:
+    async def base_char_read(self, characteristic: str) -> bytearray:
         """Read characteristic value from uuid
 
         :param uuid: characteristic uuid
         """
-        return await self.client.read_gatt_char(uuid)
+        if characteristic not in CHARACTERISTICS:
+            raise ValueError("Invalid characteristic")
+        
+        uuid = CHARACTERISTICS[characteristic]
+        length = CHARACTERISTIC_READ_LENGTHS[characteristic]
+
+        if length == -1:
+            raise ValueError("Characteristic not supported for read")
+
+        result = await self.client.read_gatt_char(uuid)
+
+        return result[:length]
 
     @requires_connection
-    async def base_char_write(self, uuid: str, data: bytearray) -> None:
+    async def base_char_write(self, characteristic: str, data: bytearray) -> None:
         """Write characteristic value from uuid
 
         :param uuid: characteristic uuid
         :param data: data to write
         """
+        if characteristic not in CHARACTERISTICS:
+            raise ValueError("Invalid characteristic")
+        
+        uuid = CHARACTERISTICS[characteristic]
+        length = CHARACTERISTIC_WRITE_LENGTHS[characteristic]
+
+        if length == -1:
+            raise ValueError("Characteristic not supported for write")
+        # elif len(data) != length:
+        #     raise ValueError("Incorrect write length provided")
+        
         await self.client.write_gatt_char(uuid, data)
 
     @requires_connection
@@ -144,6 +258,16 @@ class AsyncClient:
         Disconnect from the client.
         Also stop the notification on 0x6f52 before.
         """
+
+        if self.facet_notify_active:
+            await self.unregister_notify_facet_v3()
+        
+        if self.event_notify_active:
+            await self.unregister_notify_event_v4()
+        
+        if self.history_notify_active:
+            await self.unregister_notify_history_v4()
+            
 
         if self.facet_callback:
             try:
@@ -170,7 +294,7 @@ class AsyncClient:
         """
 
         return int.from_bytes(
-            await self.base_char_read(CHARACTERISTICS['battery_level']), BLUETOOTH_ENDIANNESS)
+            await self.base_char_read('battery_level'), BLUETOOTH_ENDIANNESS)
 
     @requires_connection
     async def firmware_revision(self) -> str:
@@ -179,7 +303,7 @@ class AsyncClient:
         :return: revision version
         """
 
-        return (await self.base_char_read(CHARACTERISTICS['firmware_revision'])).decode('ascii')
+        return (await self.base_char_read('firmware_revision')).decode('ascii')
 
     @requires_connection
     async def device_name(self) -> str:
@@ -188,7 +312,7 @@ class AsyncClient:
         :return: device name
         """
 
-        return (await self.base_char_read(CHARACTERISTICS['device_name'])).decode('ascii')
+        return (await self.base_char_read('device_name')).decode('ascii')
 
     # client specific characteristics:
 
@@ -200,13 +324,14 @@ class AsyncClient:
         so return value is True
         """
 
-        await self.base_char_write(CHARACTERISTICS['password_input'], bytearray(password.encode('ascii')))
+        await self.base_char_write('password_input', bytearray(password.encode('ascii')))
         self.logged = True
         return self.logged
 
     @requires_connection
     async def setup(self, facet_callback: Callable[[str, Any], Any] = None, password: str = DEFAULT_PASSWORD) -> None:
         """
+        + Get firmware version
         + Log in,
         + Setup the notification callback on 0x6f52 (if any)
         + Get status to update internals
@@ -217,6 +342,43 @@ class AsyncClient:
         :param password: password
         :raise NotLoggedInError: if login fails
         """
+
+        # Firmware string like FW_vX.XX, so get a useable
+        # float value to compare against
+        firmware_revision = await self.firmware_revision()
+        self.firmware_version = float(firmware_revision[4:8])
+
+        if self.firmware_version >= 3.47:
+            # Consistent functions between versions
+            self.get_status = self.get_status_v3
+            self.set_paused = self.set_pause_v3
+            self.set_lock = self.set_lock_v3
+            self.set_auto_pause = self.set_auto_pause_v3
+            self.set_name = self.set_name_v3
+            self.set_password = self.set_password_v3
+
+            # New or changed in version 4
+            self.get_time = self.get_time_v4
+            self.set_time = self.set_time_v4
+            self.set_brightness = self.set_brightness_v4
+            self.set_blink_frequency = self.set_blink_frequency_v4
+            self.set_color = self.set_color_v4
+            self.set_facet = self.set_facet_v4
+            self.get_facet = self.get_facet_v4
+            self.get_all_facets = self.get_all_facets_v4
+            self.get_event = self.get_event_v4
+            self.get_history = self.get_history_v4
+            self.get_all_history = self.get_all_history_v4
+
+            # Deprecated in version 4
+            self.get_calibration_version = self.deprecated_function
+            self.set_calibration_version = self.deprecated_function
+        else:
+            self.get_status = self.get_status_v3
+            self.get_calibration_version = \
+                self.get_calibration_version_v3
+            self.set_calibration_version = \
+                self.set_calibration_version_v3
 
         if not await self.login(password):
             raise NotLoggedInError()
@@ -231,7 +393,7 @@ class AsyncClient:
 
         await self.client.start_notify(CHARACTERISTICS['facet'], custom_facet_callback)
 
-        current_status = await self.status()
+        current_status = await self.get_status()
         self.paused = current_status['paused']
         self.locked = current_status['locked']
         self.auto_pause_time = current_status['auto_pause_time']
@@ -248,21 +410,334 @@ class AsyncClient:
 
         if force:
             self.current_facet_value = int.from_bytes(
-                await self.base_char_read(CHARACTERISTICS['facet']), TIMEFLIP_ENDIANNESS)
+                await self.base_char_read('facet'), TIMEFLIP_ENDIANNESS)
 
         return self.current_facet_value
 
+    # utilities:
+
     @requires_login
-    async def calibration_version(self) -> int:
+    async def write_command(self, command: bytearray, check=True) -> bool:
+        """Write a command to 0x6f54. Requires login !
+
+        :param command: the command
+        :param check: check, through a read in 0x6f54, that command went ok
+        :return: True if command was ok, false otherwise. If `check` is false, return is always true
+        """
+        await self.base_char_write('command_input', command)
+
+        if check:
+            data = await self.base_char_read('command_input')
+            # First byte should contain the command, second byte should
+            # contain the status code. Everything else is unpredictable
+            # junk.
+            return data[0] == command[0] and data[1] == 0x02
+        else:
+            return True
+
+    @requires_login
+    async def write_command_and_read_output(self, command: bytearray, check=False) -> bytearray:
+        """Write a command (in 0x6f54), and then read result (in 0x6f53). Requires login !
+
+        If len of result is not 21, the password is probably incorrect, so raises ``NotLoggedInError``
+        """
+
+        went_ok = await self.write_command(command, check)
+        if not went_ok:
+            raise TimeFlipCommandError(command)
+
+        data = await self.base_char_read('command_result')
+
+        # Note: for version 3.0 this response is expected
+        # to be 21 bytes, but for newer it is expected to be
+        # 20 bytes
+
+        return data
+
+
+    # version 4 commands
+
+    """
+    Get Time, reads the internal clock of the Timeflip. 
+
+    Written to the command_input characteristic (1 byte):
+        0x07
+
+        0x07 - command code
+    
+    Read from the command_result characteristic (5 bytes):
+        0x07 0xXX 0xXX 0xXX 0xXX
+
+        0x07 - command code
+        0xXX 0xXX 0xXX 0xXX - 64-bit integer containing the number of
+               seconds since 1970
+    """
+    @requires_login
+    async def get_time_v4(self) -> int:
+        command = bytearray(1)
+        command[0] = COMMANDS['time_read']
+
+        data = await self.write_command_and_read_output(command)
+        return int.from_bytes(data[1:5], TIMEFLIP_ENDIANNESS)
+
+    """
+    Set Time, sets the internal clock of the Timeflip. 
+
+    Written to the command_input characteristic (5 bytes):
+
+        0x08 - command code
+        0xXX - 64-bit integer containing the number of 
+        0xXX   seconds since 1970    
+        0xXX 
+        0xXX
+               
+    """
+    @requires_login
+    async def set_time_v4(self, time) -> None:
+        command = bytearray(5)
+        command[0] = COMMANDS['time_write']
+        command[1:5] = time.to_bytes(4, TIMEFLIP_ENDIANNESS)
+
+        await self.write_command(command)
+
+    """
+    Set Brightness, sets the brightness of the Timeflip LEDs.
+
+    Written to the command_input characteristic (2 bytes):
+
+        0x09 - command code
+        0xXX - brightness percent, (0 - 100)
+
+    """
+    @requires_login
+    async def set_brightness_v4(self, brightness) -> None:
+        command = bytearray(2)
+        command[0] = COMMANDS['brightness_set']
+        command[1] = brightness
+
+        await self.write_command(command)
+
+    """
+    Set Blink Frequency, sets the delay between conseutive LED flashes
+    from the Timeflip
+
+    Written to the command_input characteristic (2 bytes):
+
+        0x0A - command code
+        0xXX - delay in seconds, (5 - 60)
+
+    """
+    @requires_login
+    async def set_blink_frequency_v4(self, blink_frequency) -> None:
+        command = bytearray(2)
+        command[0] = COMMANDS['blink_freq_set']
+        command[1] = brightness
+
+        await self.write_command(command)
+
+    """
+    Set Facet Color, sets the color in RGB format for a given facet
+    of the Timeflip.
+
+    Written to the command_input characteristic (7 bytes):
+
+        0x11 - command code
+        0xNN - facet to set the color of (0-24)
+        0xRR - amount of red (0-255)
+        0xGG - amount of green (0-255)
+        0xBB - amount of blue (0-255)
+
+    """
+    @requires_login
+    async def set_color_v4(self, facet: int, rgb: Tuple[int, int, int]):
+        command = bytearray(5)
+        command[0] = COMMANDS['color_set'][0]
+        command[1] = facet
+        command[2] = rgb[0]
+        command[3] = rgb[1]
+        command[4] = rgb[2]
+
+        await self.write_command(command)
+
+    """
+    Set Facet command. Used to set the mode of a given facet and the pomodoro
+    time limit, if it is in pomodoro mode.
+
+    Written to the command_input characteristic (7 bytes):
+
+        0x13 0xNN 0xPP 0xTT 0xTT 0xTT 0xTT
+
+        0x13 - command code
+        0xNN - facet number (0 - 24)
+        0xPP - mode 
+            0 for normal
+            1 for pomodoro
+        0xTT 0xTT 0xTT 0xTT - 64-bit unsigned integer for the pomodoro
+                              timer limit in seconds
+
+    """
+    @requires_login
+    async def set_facet_v4(self, facet: int, mode: int, pomodoro: int) -> None:
+        command = bytearray(7)
+        command[0] = int.from_bytes(COMMANDS['facet_write'], 'big')
+        command[1] = facet
+        command[2] = mode
+        command[3:6] = pomodoro.to_bytes(4, 'big')
+
+        await self.write_command(command, True)
+
+        del command[:]
+
+    @requires_login
+    async def get_facet_v4(self, facet: int) -> Tuple[int, int, int]:
+        command = bytearray(2)
+        command[0] = int.from_bytes(COMMANDS['facet_read'], 'big')
+        command[1] = facet
+
+        data = await self.write_command_and_read_output(command, True)
+        del command[:]
+
+        return (
+            data[1],
+            data[2],
+            int.from_bytes(data[3:7], TIMEFLIP_ENDIANNESS),
+            int.from_bytes(data[7:11], 'big')
+        )
+
+    @requires_login
+    async def get_all_facets_v4(self) -> List[Tuple[int, int, int]]:
+        data = []
+
+        for i in range(0,12):
+            facet_data = await self.get_facet(i)
+            data.append(facet_data)
+
+        return data
+
+    @requires_login
+    async def get_event_v4(self) -> str:
+        return str(await self.base_char_read('event_data'))
+
+    @requires_login
+    async def register_notify_event_v4(self, event_callback: Callable[[str, Any], Any]):
+        await self.client.start_notify(CHARACTERISTICS['event_data'], event_callback)
+
+        self.event_notify_active = True
+    
+    @requires_login
+    async def unregister_notify_event_v4(self):
+        await self.client.stop_notify(CHARACTERISTICS['event_data'])
+
+        self.event_notify_active = False
+
+    @requires_login
+    async def get_history_v4(self, event_num: int) -> Tuple[int, int, int, int]:
+        """Get the history
+        """
+        command = bytearray(5)
+        command[0] = 0x01
+        command[1:5] = event_num.to_bytes(4,'big')
+
+        await self.base_char_write('history_data', command)
+
+        data = await self.base_char_read('history_data')
+        return (
+            int.from_bytes(data[0:4], TIMEFLIP_ENDIANNESS),  # event number
+            data[4],
+            int.from_bytes(data[5:13], TIMEFLIP_ENDIANNESS), # timestamp of flip(?)
+            int.from_bytes(data[13:18], 'little') # duration of flip
+        )
+
+    @requires_login
+    async def get_all_history_v4(self) -> List[Tuple[int, int, int, int]]:
+        """Get the history
+        """
+        event_number = 0
+
+        _17zeros = bytearray(17)  # mark the end of history
+
+        history_blocks = []
+
+        while True:
+            command = bytearray(5)
+            command[0] = 0x02
+            command[1:5] = event_number.to_bytes(4,'big')
+
+            await self.base_char_write('history_data', command)
+
+            data = await self.base_char_read('history_data')
+
+            if data[0:17] == _17zeros:
+                break
+
+            history_blocks.append((
+                int.from_bytes(data[0:4], TIMEFLIP_ENDIANNESS),  # event number
+                data[4],
+                int.from_bytes(data[5:13], TIMEFLIP_ENDIANNESS), # timestamp of flip(?)
+                int.from_bytes(data[13:18], 'little') # duration of flip
+            ))
+            
+            #increment bytes
+            event_number = event_number + 1
+            del command[:]
+
+        #num_blocks = int.from_bytes(first_pack, TIMEFLIP_ENDIANNESS)
+        return history_blocks
+
+    @requires_login
+    async def register_notify_history_v4(self, history_callback: Callable[[str, Any], Any]):
+        await self.client.start_notify(CHARACTERISTICS['history_data'], history_callback)
+
+        self.history_notify_active = True
+    
+    @requires_login
+    async def unregister_notify_history_v4(self):
+        await self.client.stop_notify(CHARACTERISTICS['history_data'])
+
+        self.history_notify_active = False
+
+    # version 3 commands
+
+    @requires_login
+    async def register_notify_facet_v3(self, facet_callback: Callable[[str, Any], Any]):
+        await self.client.start_notify(CHARACTERISTICS['facet'], facet_callback)
+
+        self.facet_notify_active = True
+    
+    @requires_login
+    async def unregister_notify_facet_v3(self):
+        await self.client.stop_notify(CHARACTERISTICS['facet'])
+
+        self.facet_notify_active = False
+
+    @requires_login
+    async def get_status_v3(self) -> dict:
+        """Get status (command 0x10) on pause, lock and auto-pause. Requires login !
+
+        If not logged in properly, the data size is not 21, so raises ``NotLoggedIn``
+
+        :return: a dict containing the pause, lock and auto-pause status
+        """
+
+        data = await self.write_command_and_read_output(COMMANDS['status'])
+
+        return {
+            'locked': data[0] == 0x01,
+            'paused': data[1] == 0x01,
+            'auto_pause_time': int.from_bytes(data[2:4], TIMEFLIP_ENDIANNESS)
+        }
+
+    @requires_login
+    async def get_calibration_version_v3(self) -> int:
         """Get calibration version. Requires login !
 
         :return: an integer
         """
 
-        return int.from_bytes(await self.base_char_read(CHARACTERISTICS['calibration_version']), TIMEFLIP_ENDIANNESS)
+        return int.from_bytes(await self.base_char_read('calibration_version'), TIMEFLIP_ENDIANNESS)
 
     @requires_login
-    async def set_calibration_version(self, version: int) -> None:
+    async def set_calibration_version_v3(self, version: int) -> None:
         """Set calibration version
 
         :param version: the version (any number on 4 bytes)
@@ -275,7 +750,7 @@ class AsyncClient:
             CHARACTERISTICS['calibration_version'], bytearray(int.to_bytes(version, 4, TIMEFLIP_ENDIANNESS)))
 
     @requires_login
-    async def accelerometer_value(self, multiplier: float = 1.0) -> Tuple[float, float, float]:
+    async def get_accelerometer_value_v3(self, multiplier: float = 1.0) -> Tuple[float, float, float]:
         """Get accelerometer vector
 
         .. note::
@@ -297,67 +772,13 @@ class AsyncClient:
 
         divider = 2**14
 
-        data = await self.base_char_read(CHARACTERISTICS['accelerometer_data'])
+        data = await self.base_char_read('accelerometer_data')
         ax, ay, az = struct.unpack('<hhh', data)
 
         return ax / divider * multiplier, ay / divider * multiplier, az / divider * multiplier
 
-    # commands:
-
     @requires_login
-    async def write_command(self, command: bytearray, check=True) -> bool:
-        """Write a command to 0x6f54. Requires login !
-
-        :param command: the command
-        :param check: check, through a read in 0x6f54, that command went ok
-        :return: True if command was ok, false otherwise. If `check` is false, return is always true
-        """
-
-        await self.base_char_write(CHARACTERISTICS['command_input'], command)
-
-        if check:
-            data = await self.base_char_read(CHARACTERISTICS['command_input'])
-            return data[0] == command[0] and data[-1] == 0x02
-        else:
-            return True
-
-    @requires_login
-    async def write_command_and_read_output(self, command: bytearray, check=False) -> bytearray:
-        """Write a command (in 0x6f54), and then read result (in 0x6f53). Requires login !
-
-        If len of result is not 21, the password is probably incorrect, so raises ``NotLoggedInError``
-        """
-
-        went_ok = await self.write_command(command, check)
-        if not went_ok:
-            raise TimeFlipCommandError(command)
-
-        data = await self.base_char_read(CHARACTERISTICS['command_result'])
-
-        if len(data) != 21:
-            raise NotLoggedInError()
-
-        return data
-
-    @requires_login
-    async def status(self) -> dict:
-        """Get status (command 0x10) on pause, lock and auto-pause. Requires login !
-
-        If not logged in properly, the data size is not 21, so raises ``NotLoggedIn``
-
-        :return: a dict containing the pause, lock and auto-pause status
-        """
-
-        data = await self.write_command_and_read_output(COMMANDS['status'])
-
-        return {
-            'locked': data[0] == 0x01,
-            'paused': data[1] == 0x01,
-            'auto_pause_time': int.from_bytes(data[2:4], TIMEFLIP_ENDIANNESS)
-        }
-
-    @requires_login
-    async def pause(self, state: bool, force: bool = False) -> bool:
+    async def set_pause_v3(self, state: bool, force: bool = False) -> bool:
         """Set (or unset) pause (command 0x04). Update internal. Requires login.
 
         .. note::
@@ -377,7 +798,7 @@ class AsyncClient:
         return self.paused
 
     @requires_login
-    async def lock(self, state: bool, force: bool = False) -> bool:
+    async def set_lock_v3(self, state: bool, force: bool = False) -> bool:
         """Set (or unset) lock (command 0x06). Update internal. Requires login.
 
         .. note::
@@ -396,8 +817,21 @@ class AsyncClient:
 
         return self.locked
 
+    """
+    Set Auto Pause command. Used to set the number of minutes until the
+    timeflip automatically pauses a timer for a given side. 
+    
+    Default value is 5 minutes. If this value is set to 0, the timer
+    does not automatically pause.
+
+    Written to the command_input characeristics (3 bytes):
+        0x05 0xXX 0xXX
+
+        0x05 - command code
+        0xXX 0xXX - number of minutes until automatic pause
+    """
     @requires_login
-    async def set_auto_pause(self, time: int) -> None:
+    async def set_auto_pause_v3(self, time: int) -> None:
         """Set auto-pause (command 0x05).
 
         .. warning::
@@ -416,7 +850,7 @@ class AsyncClient:
         self.auto_pause_time = time
 
     @requires_login
-    async def set_name(self, name: str) -> bool:
+    async def set_name_v3(self, name: str) -> bool:
         """Set a new name to the device (0x15)
         """
 
@@ -429,7 +863,7 @@ class AsyncClient:
         return await self.write_command(_com(command), check=True)
 
     @requires_login
-    async def set_password(self, password: str) -> bool:
+    async def set_password_v3(self, password: str) -> bool:
         """Set a new password (0x30)
 
         :param password: 6-letter long password
@@ -442,9 +876,9 @@ class AsyncClient:
         command = [0x30]
         command.extend(password)
         return await self.write_command(_com(command), check=True)
-
+    
     @requires_login
-    async def history(self) -> List[Tuple[int, int, bytearray]]:
+    async def history_v3(self) -> List[Tuple[int, int, bytearray]]:
         """Get the history
 
         .. note::
@@ -465,7 +899,7 @@ class AsyncClient:
         first_pack = None
 
         while True:
-            data = await self.base_char_read(CHARACTERISTICS['command_result'])
+            data = await self.base_char_read('command_result')
 
             if data == _21zeros:
                 break
@@ -494,6 +928,13 @@ class AsyncClient:
         """
 
         await self.write_command(COMMANDS['calibration_reset'])
+
+    # 
+    async def deprecated_function(self) -> None:
+        raise DeprecatedFunctionError()
+    
+    async def unimplemented_function(self) -> None:
+        raise UnimplementedFunctionError()
 
     # async contexts:
 

--- a/pytimefliplib/async_client.py
+++ b/pytimefliplib/async_client.py
@@ -14,8 +14,7 @@ UUID_TIMEFLIP = 'f119{:x}-71a4-11e6-bdf4-0800200c9a66'
 DEFAULT_PASSWORD = '000000'
 
 BLUETOOTH_ENDIANNESS = 'little'
-#TIMEFLIP_ENDIANNESS = BLUETOOTH_ENDIANNESS  # it was not clear, but based on history read out, it is little endian
-TIMEFLIP_ENDIANNESS = 'big'
+TIMEFLIP_ENDIANNESS = BLUETOOTH_ENDIANNESS  # it was not clear, but based on history read out, it is little endian
 
 CHARACTERISTICS = {
     # generic
@@ -371,6 +370,10 @@ class AsyncClient:
 
         # For version 4 these functions are different
         if self.firmware_version >= 3.47:
+            # Version 4 protocol appears to use big rather than little
+            # endianness for certain characteristics
+            TIMEFLIP_ENDIANNESS = 'big'
+
             # New or changed in version 4
             self.get_time = self.get_time_v4
             self.set_time = self.set_time_v4
@@ -381,8 +384,8 @@ class AsyncClient:
             self.get_facet = self.get_facet_v4
             self.get_all_facets = self.get_all_facets_v4
             self.get_event = self.get_event_v4
-            self.get_history = self.get_history_v4
-            self.get_all_history = self.get_all_history_v4
+            self.get_history = self.unimplemented_function
+            self.get_all_history = self.unimplemented_function
 
             # Deprecated in version 4
             self.get_calibration_version = self.deprecated_function
@@ -681,7 +684,7 @@ class AsyncClient:
             history_blocks.append((
                 int.from_bytes(data[0:4], TIMEFLIP_ENDIANNESS),  # event number
                 data[4],
-                int.from_bytes(data[5:13], TIMEFLIP_ENDIANNESS), # timestamp of flip(?)
+                int.from_bytes(data[5:13], TIMEFLIP_ENDIANNESS),  # timestamp of flip(?)
                 int.from_bytes(data[13:18], 'little') # duration of flip
             ))
             
@@ -689,7 +692,6 @@ class AsyncClient:
             event_number = event_number + 1
             del command[:]
 
-        #num_blocks = int.from_bytes(first_pack, TIMEFLIP_ENDIANNESS)
         return history_blocks
 
     @requires_login

--- a/pytimefliplib/scripts/check.py
+++ b/pytimefliplib/scripts/check.py
@@ -39,8 +39,6 @@ async def actions_on_client(client: AsyncClient, args: argparse.Namespace):
                 .format(number, mode, pomodoro, timer)
             )
 
-        #await client.set_facet(1,1,300)
-
         # print history
         print('History::')
         history = await client.get_all_history()

--- a/pytimefliplib/scripts/check.py
+++ b/pytimefliplib/scripts/check.py
@@ -13,27 +13,43 @@ async def actions_on_client(client: AsyncClient, args: argparse.Namespace):
     print('- Firmware:', await client.firmware_revision())
     print('- Battery:', await client.battery_level())
     print('- Current facet:', await client.current_facet())
-    #print('- Accelerometer vector:', ', '.join('{:.3f}'.format(x) for x in await client.accelerometer_value()))
-    print('- Status:', await client.get_status())
 
-    print('Facets::')
-    facets = await client.get_all_facets()
-    for number, mode, pomodoro, timer in facets:
-        print('- Facet={} mode: {}, pomodoro time: {}, timer: {}'
-              .format(number, mode, pomodoro, timer)
-        )
 
-    #await client.set_facet(1,1,300)
+    if client.firmware_version < 3.47:
+        print('- Accelerometer vector:', ', '.join('{:.3f}'.format(x) for x in await client.accelerometer_value()))
+        print('- Status:', await client.status())
 
-    # print history
-    print('History::')
-    history = await client.get_all_history()
-    for number, facet, orig, duration in history:
-        print('- Event {} on facet {} ({} seconds) from {}'.format(number, facet, duration, orig))
+        # print history
+        print('History::')
+        start = datetime.now()
+        history = await client.history()
+        total_time = sum(h[1] for h in history)
+        start -= timedelta(microseconds=start.microsecond) + timedelta(seconds=total_time)
+        for facet, duration, orig in history:
+            end = start + timedelta(seconds=duration)
+            print('- Facet={} ({} seconds): from {} to {}'.format(facet, duration, start.isoformat(), end.isoformat()))
+            start = end
+    else:
+        print('- Status:', await client.get_status())
 
-    # print event
-    event = await client.get_event()
-    print("Event: {}", event)
+        print('Facets::')
+        facets = await client.get_all_facets()
+        for number, mode, pomodoro, timer in facets:
+            print('- Facet={} mode: {}, pomodoro time: {}, timer: {}'
+                .format(number, mode, pomodoro, timer)
+            )
+
+        #await client.set_facet(1,1,300)
+
+        # print history
+        print('History::')
+        history = await client.get_all_history()
+        for number, facet, orig, duration in history:
+            print('- Event {} on facet {} ({} seconds) from {}'.format(number, facet, duration, orig))
+
+        # print event
+        event = await client.get_event()
+        print("Event: {}", event)
 
 
 def main():

--- a/pytimefliplib/scripts/check.py
+++ b/pytimefliplib/scripts/check.py
@@ -12,21 +12,28 @@ async def actions_on_client(client: AsyncClient, args: argparse.Namespace):
     print('- Name:', await client.device_name())
     print('- Firmware:', await client.firmware_revision())
     print('- Battery:', await client.battery_level())
-    print('- Calibration:', await client.calibration_version())
     print('- Current facet:', await client.current_facet())
-    print('- Accelerometer vector:', ', '.join('{:.3f}'.format(x) for x in await client.accelerometer_value()))
-    print('- Status:', await client.status())
+    #print('- Accelerometer vector:', ', '.join('{:.3f}'.format(x) for x in await client.accelerometer_value()))
+    print('- Status:', await client.get_status())
+
+    print('Facets::')
+    facets = await client.get_all_facets()
+    for number, mode, pomodoro, timer in facets:
+        print('- Facet={} mode: {}, pomodoro time: {}, timer: {}'
+              .format(number, mode, pomodoro, timer)
+        )
+
+    #await client.set_facet(1,1,300)
 
     # print history
     print('History::')
-    start = datetime.now()
-    history = await client.history()
-    total_time = sum(h[1] for h in history)
-    start -= timedelta(microseconds=start.microsecond) + timedelta(seconds=total_time)
-    for facet, duration, orig in history:
-        end = start + timedelta(seconds=duration)
-        print('- Facet={} ({} seconds): from {} to {}'.format(facet, duration, start.isoformat(), end.isoformat()))
-        start = end
+    history = await client.get_all_history()
+    for number, facet, orig, duration in history:
+        print('- Event {} on facet {} ({} seconds) from {}'.format(number, facet, duration, orig))
+
+    # print event
+    event = await client.get_event()
+    print("Event: {}", event)
 
 
 def main():

--- a/pytimefliplib/scripts/discover.py
+++ b/pytimefliplib/scripts/discover.py
@@ -31,7 +31,7 @@ async def run():
                 except BleakError:
                     devices_map['not_timeflip'].append(d)
 
-        except (BleakError, asyncio.exceptions.TimeoutError):
+        except (BleakError, asyncio.TimeoutError):
             devices_map['connection_issue'].append(d)
 
     print(' Done!')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 autopep8==1.5.7
     # via -r requirements/requirements.in
-bleak==0.12.1
+bleak==0.20.2
     # via -r requirements/requirements-base.in
 dbus-next==0.2.3
     # via bleak


### PR DESCRIPTION
Okay so here's the big notes about the changes I made:
- added an optional parameter to the client constructor that will be invoked on disconnect
- `base_char_read` and `base_char_write` now expect a string key for the characteristic
rather than the UUID value itself. This allows them to look up the UUID and expected
lengths of data being read/written from the buffer based on the key, which fixes a bug
I had seen in which reading/writing from the buffer without a specific length for substringing
would grab a bunch of garbage data
- upon setup the library will attempt to detect the firmware revision of the Timeflip
and use the protocols that are appropriate for that version